### PR TITLE
Links to wordpress blog.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -10,7 +10,7 @@
     {% if page.title == "blog" %}
       <p class="dib under"><a class="link-reverse phs" href="#">Blog</a></p>
     {% else %}
-      <p class="dib"><a class="link-reverse phs" href="/blog.html">Blog</a></p>
+      <p class="dib"><a class="link-reverse phs" href="http://blog.joinoneroom.com">Blog</a></p>
     {% endif %}
 
     {% if page.title == "team" %}


### PR DESCRIPTION
Ok, I changed the link in the header. I'm pretty sure that's the only place we've linked to it.

I did a little research on whether it's possible to redirect the old blog posts to the new ones, and I haven't found anything definitive, but [this](http://codingtips.kanishkkunal.in/redirects-jekyll-github-pages/) looks promising and I'll look into it more.
